### PR TITLE
Fix subsetting of dates in marketable_all

### DIFF
--- a/R/maketable_all.R
+++ b/R/maketable_all.R
@@ -39,11 +39,11 @@ maketable_all <- function(df=NULL, Season=NULL, tier=NULL, pts=3, begin=NULL, en
 
     #dates
     if(!is.null(begin) & is.null(end)) {
-      dfx <- dfx[(dfx$Date >= begin & dfx$Date <= end), ]
+      dfx <- dfx[(dfx$Date >= begin), ]
     } else if(is.null(begin) & !is.null(end)) {
       dfx <- dfx[(dfx$Date <= end), ]
     } else if(!is.null(begin) & !is.null(end)) {
-      dfx <- dfx[(dfx$Date >= begin), ]
+      dfx <- dfx[(dfx$Date >= begin & dfx$Date <= end), ]
     }
 
 


### PR DESCRIPTION
Fixes a bug in choosing dates in `marketable_all()`. Also would be useful to make Dates actual time format. Currently I have to `as.POSIXct()` before doing a subset.